### PR TITLE
Use new @types repository for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/101100/nmea-simple/issues"
   },
   "scripts": {
-    "build": "npm run lint && typings install && tsc",
+    "build": "npm run lint && tsc",
     "lint": "tslint *.ts codecs/*.ts tests/*.ts",
     "prepublish": "npm run test",
     "test": "npm run build && mocha -R tap dist/tests"
@@ -35,11 +35,12 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
-    "mocha": "^2.3",
-    "should": "^8.0",
-    "tslint": "^3.13",
-    "typescript": "^2.0",
-    "typings": "^1.3.1"
+    "@types/mocha": "^2.2",
+    "@types/should": "^8.1",
+    "mocha": "^3.1",
+    "should": "^11.1",
+    "tslint": "^3.15",
+    "typescript": "^2.0"
   },
   "dependencies": {}
 }

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,0 @@
-{
-  "globalDependencies": {
-    "mocha": "registry:env/mocha#2.2.5+20160321223601",
-    "should": "registry:dt/should#8.1.1+20160608082854"
-  }
-}


### PR DESCRIPTION
This allows the removal of the `typings` utility.

I've confirmed that the compiled JavaScript does not change.  This is a heads up pull request.

This will be released as 2.1.0.
