### PR TITLE
Extensibility and graceful error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 # NMEA 0183 sentence parser and encoder
 
 This library parses and encodes some NMEA 0183 sentences.  These are typically
-used by GPS recievers to send information on position, heading, speed and
-acuracy.  The official standard can be found
+used by GPS receivers to send information on position, heading, speed and
+accuracy.  The official standard can be found
 [here](http://www.nmea.org/content/nmea_standards/nmea_0183_v_410.asp) and is
 described in clear terms [here](http://catb.org/gpsd/NMEA.html).
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,55 @@ This is a fork of the [nmea](https://www.npmjs.com/package/nmea) package with
 all dependencies removed and TypeScript typing information added.
 
 
+## Extending the library
+
+### Custom packets
+
+Custom (proprietary) sentences can be defined with type assurance and added to the parsing algorithm by supplying a custom factory which overrides the `assembleCustomPacket` function of `DefaultPacketFactory` class.
+
+
+```ts
+const logSentenceId: "LOG" = "LOG";
+
+export interface LogPacket extends PacketStub<typeof logSentenceId> {
+    logNum: number;
+    logMsg: string;
+}
+
+class CustomPacketFactory extends DefaultPacketFactory<LogPacket> {
+    assembleCustomPacket(stub: PacketStub, fields: string[]): LogPacket | null {
+        if (stub.sentenceId === logSentenceId) {
+            return {
+                ...initStubFields(logSentenceId, stub),
+                logNum: parseInt(fields[1], 10),
+                logMsg: fields[2]
+            };
+        }
+
+        return null;
+    }
+}
+
+export const CUSTOM_PACKET_FACTORY = new CustomPacketFactory();
+```
+
+This extends the first example the following way:
+
+```js
+    try {
+        const packet = nmea.parseGenericPacket(line, CUSTOM_PACKET_FACTORY);
+
+        if (packet.sentenceId === "LOG") {
+            console.log("Got a log message:", packet.logMsg);
+        }
+
+    ...
+```
+
+Make sure not to conflict with built in sentence types!
+
+For more info see **CustomPacketsTest.ts**
+
 ## Acknowledgements
 
 This module was based on the NPM [nmea](https://www.npmjs.com/package/nmea) and

--- a/README.md
+++ b/README.md
@@ -154,13 +154,18 @@ For more info see **CustomPacketsTest.ts**
 
 ### Unsafe packets
 
-It might be desired to investigate packets that are not recognized. (For example analyzing occurrence frequency.) For this we can use `parseUnsafeNmeaSentence`.
+It might be desired to investigate packets that are not recognized or have bad checksum. (For example analyzing occurrence frequency.) For this we can use `parseUnsafeNmeaSentence`.
 
 This function will parse every packet, even if the ID is unrecognized. `sentenceId` for these packets are always `?`.
 
 ```js
     try {
         const packet = nmea.parseUnsafeNmeaSentence(line);
+
+        if (packet.chxOk !== true) {
+            console.log("Skipping packet with bad checksum:");
+            return;
+        }
 
         if (packet.sentenceId === "?") {
             console.log("Got an unknown packet with signature:", packet.fields[0]);

--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ Make sure not to conflict with built in sentence types!
 
 For more info see **CustomPacketsTest.ts**
 
+### Unsafe packets
+
+It might be desired to investigate packets that are not recognized. (For example analyzing occurrence frequency.) For this we can use `parseUnsafeNmeaSentence`.
+
+This function will parse every packet, even if the ID is unrecognized. `sentenceId` for these packets are always `?`.
+
+```js
+    try {
+        const packet = nmea.parseUnsafeNmeaSentence(line);
+
+        if (packet.sentenceId === "?") {
+            console.log("Got an unknown packet with signature:", packet.fields[0]);
+        }
+
+    ...
+```
+
 ## Acknowledgements
 
 This module was based on the NPM [nmea](https://www.npmjs.com/package/nmea) and

--- a/codecs/APB.ts
+++ b/codecs/APB.ts
@@ -34,15 +34,14 @@
  */
 
 import { parseFloatSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "APB" = "APB";
 export const sentenceName = "Autopilot sentence \"B\"";
 
 
-export interface APBPacket extends PacketStub {
-    sentenceId: "APB";
+export interface APBPacket extends PacketStub<typeof sentenceId> {
     status1: string;
     status2: string;
     xteMagn: number;
@@ -60,10 +59,9 @@ export interface APBPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): APBPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): APBPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         status1: fields[1],
         status2: fields[2],
         xteMagn: parseFloatSafe(fields[3]),

--- a/codecs/APB.ts
+++ b/codecs/APB.ts
@@ -34,16 +34,15 @@
  */
 
 import { parseFloatSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "APB" = "APB";
 export const sentenceName = "Autopilot sentence \"B\"";
 
 
-export interface APBPacket {
+export interface APBPacket extends PacketStub {
     sentenceId: "APB";
-    sentenceName?: string;
-    talkerId?: string;
     status1: string;
     status2: string;
     xteMagn: number;

--- a/codecs/BWC.ts
+++ b/codecs/BWC.ts
@@ -27,16 +27,15 @@
 
 
 import { parseFloatSafe, parseLatitude, parseLongitude, parseTime } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "BWC" = "BWC";
 export const sentenceName = "Bearing and distance to waypoint - great circle";
 
 
-export interface BWCPacket {
+export interface BWCPacket extends PacketStub {
     sentenceId: "BWC";
-    sentenceName?: string;
-    talkerId?: string;
     time: Date;
     bearingLatitude: number;
     bearingLongitude: number;

--- a/codecs/BWC.ts
+++ b/codecs/BWC.ts
@@ -27,15 +27,14 @@
 
 
 import { parseFloatSafe, parseLatitude, parseLongitude, parseTime } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "BWC" = "BWC";
 export const sentenceName = "Bearing and distance to waypoint - great circle";
 
 
-export interface BWCPacket extends PacketStub {
-    sentenceId: "BWC";
+export interface BWCPacket extends PacketStub<typeof sentenceId> {
     time: Date;
     bearingLatitude: number;
     bearingLongitude: number;
@@ -47,10 +46,9 @@ export interface BWCPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): BWCPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): BWCPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         time: parseTime(fields[1]),
         bearingLatitude: parseLatitude(fields[2], fields[3]),
         bearingLongitude: parseLongitude(fields[4], fields[5]),

--- a/codecs/DBT.ts
+++ b/codecs/DBT.ts
@@ -18,16 +18,15 @@
  */
 
 import { createNmeaChecksumFooter, encodeFixed, parseFloatSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "DBT" = "DBT";
 export const sentenceName = "Depth below transducer";
 
 
-export interface DBTPacket {
+export interface DBTPacket extends PacketStub {
     sentenceId: "DBT";
-    sentenceName?: string;
-    talkerId?: string;
     depthFeet: number;
     depthMeters: number;
     depthFathoms: number;

--- a/codecs/DBT.ts
+++ b/codecs/DBT.ts
@@ -18,25 +18,23 @@
  */
 
 import { createNmeaChecksumFooter, encodeFixed, parseFloatSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "DBT" = "DBT";
 export const sentenceName = "Depth below transducer";
 
 
-export interface DBTPacket extends PacketStub {
-    sentenceId: "DBT";
+export interface DBTPacket extends PacketStub<typeof sentenceId> {
     depthFeet: number;
     depthMeters: number;
     depthFathoms: number;
 }
 
 
-export function decodeSentence(fields: string[]): DBTPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): DBTPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         depthFeet: parseFloatSafe(fields[1]),
         depthMeters: parseFloatSafe(fields[3]),
         depthFathoms: parseFloatSafe(fields[5])

--- a/codecs/DTM.ts
+++ b/codecs/DTM.ts
@@ -26,7 +26,7 @@
 
 
 import { parseFloatSafe, parseLatitude, parseLongitude } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "DTM" = "DTM";
@@ -43,8 +43,7 @@ export const sentenceName = "Datum reference";
 export type DatumCode = "W84" | "W72" | "S85" | "P90" | "999" | "";
 
 
-export interface DTMPacket extends PacketStub {
-    sentenceId: "DTM";
+export interface DTMPacket extends PacketStub<typeof sentenceId> {
     datumCode: DatumCode;
     datumSubcode?: string;
     offsetLatitude: number;
@@ -54,10 +53,9 @@ export interface DTMPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): DTMPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): DTMPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         datumCode: parseDatumCode(fields[1]),
         datumSubcode: fields[2] || undefined,
         offsetLatitude: parseLatitude(fields[3], fields[4]),

--- a/codecs/DTM.ts
+++ b/codecs/DTM.ts
@@ -26,6 +26,7 @@
 
 
 import { parseFloatSafe, parseLatitude, parseLongitude } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "DTM" = "DTM";
@@ -42,10 +43,8 @@ export const sentenceName = "Datum reference";
 export type DatumCode = "W84" | "W72" | "S85" | "P90" | "999" | "";
 
 
-export interface DTMPacket {
+export interface DTMPacket extends PacketStub {
     sentenceId: "DTM";
-    sentenceName?: string;
-    talkerId?: string;
     datumCode: DatumCode;
     datumSubcode?: string;
     offsetLatitude: number;

--- a/codecs/GGA.ts
+++ b/codecs/GGA.ts
@@ -38,6 +38,7 @@
 */
 
 import { createNmeaChecksumFooter, encodeAltitude, encodeFixed, encodeGeoidalSeperation, encodeLatitude, encodeLongitude, encodeTime, encodeValue, parseFloatSafe, parseIntSafe, parseLatitude, parseLongitude, parseTime } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GGA" = "GGA";
@@ -48,10 +49,8 @@ export type FixType = "none" | "fix" | "delta" | "pps" | "rtk" | "frtk" | "estim
 const FixTypes: FixType[] = [ "none", "fix", "delta", "pps", "rtk", "frtk", "estimated", "manual", "simulation" ];
 
 
-export interface GGAPacket {
+export interface GGAPacket extends PacketStub {
     sentenceId: "GGA";
-    sentenceName?: string;
-    talkerId?: string;
     time: Date;
     latitude: number;
     longitude: number;

--- a/codecs/GGA.ts
+++ b/codecs/GGA.ts
@@ -38,7 +38,7 @@
 */
 
 import { createNmeaChecksumFooter, encodeAltitude, encodeFixed, encodeGeoidalSeperation, encodeLatitude, encodeLongitude, encodeTime, encodeValue, parseFloatSafe, parseIntSafe, parseLatitude, parseLongitude, parseTime } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GGA" = "GGA";
@@ -49,8 +49,7 @@ export type FixType = "none" | "fix" | "delta" | "pps" | "rtk" | "frtk" | "estim
 const FixTypes: FixType[] = [ "none", "fix", "delta", "pps", "rtk", "frtk", "estimated", "manual", "simulation" ];
 
 
-export interface GGAPacket extends PacketStub {
-    sentenceId: "GGA";
+export interface GGAPacket extends PacketStub<typeof sentenceId> {
     time: Date;
     latitude: number;
     longitude: number;
@@ -64,10 +63,9 @@ export interface GGAPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): GGAPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): GGAPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         time: parseTime(fields[1]),
         latitude: parseLatitude(fields[2], fields[3]),
         longitude: parseLongitude(fields[4], fields[5]),

--- a/codecs/GLL.ts
+++ b/codecs/GLL.ts
@@ -22,15 +22,14 @@
  */
 
 import { createNmeaChecksumFooter, encodeLatitude, encodeLongitude, encodeTime, parseLatitude, parseLongitude, parseTime } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GLL" = "GLL";
 export const sentenceName = "Geographic position - latitude and longitude";
 
 
-export interface GLLPacket extends PacketStub {
-    sentenceId: "GLL";
+export interface GLLPacket extends PacketStub<typeof sentenceId> {
     latitude: number;
     longitude: number;
     time: Date;
@@ -39,10 +38,9 @@ export interface GLLPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): GLLPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): GLLPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         latitude: parseLatitude(fields[1], fields[2]),
         longitude: parseLongitude(fields[3], fields[4]),
         time: parseTime(fields[5]),

--- a/codecs/GLL.ts
+++ b/codecs/GLL.ts
@@ -22,16 +22,15 @@
  */
 
 import { createNmeaChecksumFooter, encodeLatitude, encodeLongitude, encodeTime, parseLatitude, parseLongitude, parseTime } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GLL" = "GLL";
 export const sentenceName = "Geographic position - latitude and longitude";
 
 
-export interface GLLPacket {
+export interface GLLPacket extends PacketStub {
     sentenceId: "GLL";
-    sentenceName?: string;
-    talkerId?: string;
     latitude: number;
     longitude: number;
     time: Date;

--- a/codecs/GNS.ts
+++ b/codecs/GNS.ts
@@ -35,14 +35,13 @@
 */
 
 import { createNmeaChecksumFooter, encodeAltitudeNoUnits, encodeFixed, encodeGeoidalSeperationNoUnits, encodeLatitude, encodeLongitude, encodeTime, encodeValue, parseFloatSafe, parseIntSafe, parseLatitude, parseLongitude, parseTime } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GNS" = "GNS";
 export const sentenceName = "GNSS fix data";
 
-export interface GNSPacket extends PacketStub {
-    sentenceId: "GNS";
+export interface GNSPacket extends PacketStub<typeof sentenceId> {
     time: Date;
     latitude: number;
     longitude: number;
@@ -56,10 +55,9 @@ export interface GNSPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): GNSPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): GNSPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         time: parseTime(fields[1]),
         latitude: parseLatitude(fields[2], fields[3]),
         longitude: parseLongitude(fields[4], fields[5]),

--- a/codecs/GNS.ts
+++ b/codecs/GNS.ts
@@ -35,15 +35,14 @@
 */
 
 import { createNmeaChecksumFooter, encodeAltitudeNoUnits, encodeFixed, encodeGeoidalSeperationNoUnits, encodeLatitude, encodeLongitude, encodeTime, encodeValue, parseFloatSafe, parseIntSafe, parseLatitude, parseLongitude, parseTime } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GNS" = "GNS";
 export const sentenceName = "GNSS fix data";
 
-export interface GNSPacket {
+export interface GNSPacket extends PacketStub {
     sentenceId: "GNS";
-    sentenceName?: string;
-    talkerId?: string;
     time: Date;
     latitude: number;
     longitude: number;

--- a/codecs/GSA.ts
+++ b/codecs/GSA.ts
@@ -26,7 +26,7 @@
  */
 
 import { parseFloatSafe, parseIntSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GSA" = "GSA";
@@ -37,8 +37,7 @@ export type ThreeDFixType = "unknown" | "none" | "2D" | "3D";
 const ThreeDFixTypes: ThreeDFixType[] = [ "unknown", "none", "2D", "3D" ];
 
 
-export interface GSAPacket extends PacketStub {
-    sentenceId: "GSA";
+export interface GSAPacket extends PacketStub<typeof sentenceId> {
     selectionMode: "automatic" | "manual";
     fixMode: ThreeDFixType;
     satellites: number[];
@@ -48,7 +47,7 @@ export interface GSAPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): GSAPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): GSAPacket {
     const sats: number[] = [];
 
     for (let i = 3; i < 15; i++) {
@@ -58,8 +57,7 @@ export function decodeSentence(fields: string[]): GSAPacket {
     }
 
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         selectionMode: fields[1] === "A" ? "automatic" : "manual",
         fixMode: ThreeDFixTypes[parseIntSafe(fields[2])],
         satellites: sats,

--- a/codecs/GSA.ts
+++ b/codecs/GSA.ts
@@ -26,6 +26,7 @@
  */
 
 import { parseFloatSafe, parseIntSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GSA" = "GSA";
@@ -36,10 +37,8 @@ export type ThreeDFixType = "unknown" | "none" | "2D" | "3D";
 const ThreeDFixTypes: ThreeDFixType[] = [ "unknown", "none", "2D", "3D" ];
 
 
-export interface GSAPacket {
+export interface GSAPacket extends PacketStub {
     sentenceId: "GSA";
-    sentenceName?: string;
-    talkerId?: string;
     selectionMode: "automatic" | "manual";
     fixMode: ThreeDFixType;
     satellites: number[];

--- a/codecs/GST.ts
+++ b/codecs/GST.ts
@@ -21,16 +21,15 @@
  */
 
 import { parseFloatSafe, parseTime } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GST" = "GST";
 export const sentenceName = "GPS pseudorange noise statistics";
 
 
-export interface GSTPacket {
+export interface GSTPacket extends PacketStub {
     sentenceId: "GST";
-    sentenceName?: string;
-    talkerId?: string;
     time: Date;
     totalRms: number;
     semiMajorError: number;

--- a/codecs/GST.ts
+++ b/codecs/GST.ts
@@ -21,15 +21,14 @@
  */
 
 import { parseFloatSafe, parseTime } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GST" = "GST";
 export const sentenceName = "GPS pseudorange noise statistics";
 
 
-export interface GSTPacket extends PacketStub {
-    sentenceId: "GST";
+export interface GSTPacket extends PacketStub<typeof sentenceId> {
     time: Date;
     totalRms: number;
     semiMajorError: number;
@@ -41,10 +40,9 @@ export interface GSTPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): GSTPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): GSTPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         time: parseTime(fields[1]),
         totalRms: parseFloatSafe(fields[2]),
         semiMajorError: parseFloatSafe(fields[3]),

--- a/codecs/GSV.ts
+++ b/codecs/GSV.ts
@@ -38,7 +38,7 @@
  */
 
 import { parseIntSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GSV" = "GSV";
@@ -53,8 +53,7 @@ export interface Satellite {
 }
 
 
-export interface GSVPacket extends PacketStub {
-    sentenceId: "GSV";
+export interface GSVPacket extends PacketStub<typeof sentenceId> {
     numberOfMessages: number;
     messageNumber: number;
     satellitesInView: number;
@@ -62,7 +61,7 @@ export interface GSVPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): GSVPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): GSVPacket {
     const numRecords = (fields.length - 4) / 4;
     const sats: Satellite[] = [];
 
@@ -78,8 +77,7 @@ export function decodeSentence(fields: string[]): GSVPacket {
     }
 
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         numberOfMessages: parseIntSafe(fields[1]),
         messageNumber: parseIntSafe(fields[2]),
         satellitesInView: parseIntSafe(fields[3]),

--- a/codecs/GSV.ts
+++ b/codecs/GSV.ts
@@ -38,6 +38,7 @@
  */
 
 import { parseIntSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "GSV" = "GSV";
@@ -52,10 +53,8 @@ export interface Satellite {
 }
 
 
-export interface GSVPacket {
+export interface GSVPacket extends PacketStub {
     sentenceId: "GSV";
-    sentenceName?: string;
-    talkerId?: string;
     numberOfMessages: number;
     messageNumber: number;
     satellitesInView: number;

--- a/codecs/HDG.ts
+++ b/codecs/HDG.ts
@@ -17,16 +17,15 @@
  */
 
 import { parseFloatSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "HDG" = "HDG";
 export const sentenceName = "Heading - deviation and variation";
 
 
-export interface HDGPacket {
+export interface HDGPacket extends PacketStub {
     sentenceId: "HDG";
-    sentenceName?: string;
-    talkerId?: string;
     heading: number;
     deviation: number;
     deviationDirection: "" | "E" | "W";

--- a/codecs/HDG.ts
+++ b/codecs/HDG.ts
@@ -17,15 +17,14 @@
  */
 
 import { parseFloatSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "HDG" = "HDG";
 export const sentenceName = "Heading - deviation and variation";
 
 
-export interface HDGPacket extends PacketStub {
-    sentenceId: "HDG";
+export interface HDGPacket extends PacketStub<typeof sentenceId> {
     heading: number;
     deviation: number;
     deviationDirection: "" | "E" | "W";
@@ -34,10 +33,9 @@ export interface HDGPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): HDGPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): HDGPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         heading: parseFloatSafe(fields[1]),
         deviation: parseFloatSafe(fields[2]),
         deviationDirection: fields[3] === "E" ? "E" : fields[3] === "W" ? "W" : "",

--- a/codecs/HDM.ts
+++ b/codecs/HDM.ts
@@ -15,16 +15,15 @@
 
 
 import { createNmeaChecksumFooter, encodeFixed, parseFloatSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "HDM" = "HDM";
 export const sentenceName = "Heading - magnetic";
 
 
-export interface HDMPacket {
+export interface HDMPacket extends PacketStub {
     sentenceId: "HDM";
-    sentenceName?: string;
-    talkerId?: string;
     heading: number;
 }
 

--- a/codecs/HDM.ts
+++ b/codecs/HDM.ts
@@ -15,23 +15,21 @@
 
 
 import { createNmeaChecksumFooter, encodeFixed, parseFloatSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "HDM" = "HDM";
 export const sentenceName = "Heading - magnetic";
 
 
-export interface HDMPacket extends PacketStub {
-    sentenceId: "HDM";
+export interface HDMPacket extends PacketStub<typeof sentenceId> {
     heading: number;
 }
 
 
-export function decodeSentence(fields: string[]): HDMPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): HDMPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         heading: parseFloatSafe(fields[1])
     };
 }

--- a/codecs/HDT.ts
+++ b/codecs/HDT.ts
@@ -15,16 +15,15 @@
 
 
 import { createNmeaChecksumFooter, encodeFixed, parseFloatSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "HDT" = "HDT";
 export const sentenceName = "Heading - true";
 
 
-export interface HDTPacket {
+export interface HDTPacket extends PacketStub {
     sentenceId: "HDT";
-    sentenceName?: string;
-    talkerId?: string;
     heading: number;
 }
 

--- a/codecs/HDT.ts
+++ b/codecs/HDT.ts
@@ -15,23 +15,21 @@
 
 
 import { createNmeaChecksumFooter, encodeFixed, parseFloatSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "HDT" = "HDT";
 export const sentenceName = "Heading - true";
 
 
-export interface HDTPacket extends PacketStub {
-    sentenceId: "HDT";
+export interface HDTPacket extends PacketStub<typeof sentenceId> {
     heading: number;
 }
 
 
-export function decodeSentence(fields: string[]): HDTPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): HDTPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         heading: parseFloatSafe(fields[1])
     };
 }

--- a/codecs/MTK.ts
+++ b/codecs/MTK.ts
@@ -31,7 +31,7 @@ export interface MTKPacket extends PacketStub<typeof sentenceId> {
 export function decodeSentence(stub: PacketStub, fields: string[]): MTKPacket {
     return {
         ...initStubFields(stub, sentenceId, sentenceName),
-        packetType: parseIntSafe(fields[0].substr(3)),
+        packetType: parseIntSafe(stub.sentenceId.substr(3)),
         data: fields.slice(1).map<string|number>(parseNumberOrString)
     };
 }

--- a/codecs/MTK.ts
+++ b/codecs/MTK.ts
@@ -15,16 +15,15 @@
 
 
 import { createNmeaChecksumFooter, padLeft, parseIntSafe, parseNumberOrString } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "MTK" = "MTK";
 export const sentenceName = "Configuration packet";
 
 
-export interface MTKPacket {
+export interface MTKPacket extends PacketStub {
     sentenceId: "MTK";
-    sentenceName?: string;
-    talkerId?: string;
     packetType: number;
     data: (string | number)[];
 }

--- a/codecs/MTK.ts
+++ b/codecs/MTK.ts
@@ -15,24 +15,22 @@
 
 
 import { createNmeaChecksumFooter, padLeft, parseIntSafe, parseNumberOrString } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "MTK" = "MTK";
 export const sentenceName = "Configuration packet";
 
 
-export interface MTKPacket extends PacketStub {
-    sentenceId: "MTK";
+export interface MTKPacket extends PacketStub<typeof sentenceId> {
     packetType: number;
     data: (string | number)[];
 }
 
 
-export function decodeSentence(fields: string[]): MTKPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): MTKPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         packetType: parseIntSafe(fields[0].substr(3)),
         data: fields.slice(1).map<string|number>(parseNumberOrString)
     };

--- a/codecs/MWV.ts
+++ b/codecs/MWV.ts
@@ -18,15 +18,14 @@
  */
 
 import { createNmeaChecksumFooter, encodeDegrees, encodeFixed, parseFloatSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "MWV" = "MWV";
 export const sentenceName = "Wind speed and angle";
 
 
-export interface MWVPacket extends PacketStub {
-    sentenceId: "MWV";
+export interface MWVPacket extends PacketStub<typeof sentenceId> {
     windAngle: number;
     reference: "relative" | "true";
     speed: number;
@@ -35,10 +34,9 @@ export interface MWVPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): MWVPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): MWVPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         windAngle: parseFloatSafe(fields[1]),
         reference: fields[2] === "R" ? "relative" : "true",
         speed: parseFloatSafe(fields[3]),

--- a/codecs/MWV.ts
+++ b/codecs/MWV.ts
@@ -18,16 +18,15 @@
  */
 
 import { createNmeaChecksumFooter, encodeDegrees, encodeFixed, parseFloatSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "MWV" = "MWV";
 export const sentenceName = "Wind speed and angle";
 
 
-export interface MWVPacket {
+export interface MWVPacket extends PacketStub {
     sentenceId: "MWV";
-    sentenceName?: string;
-    talkerId?: string;
     windAngle: number;
     reference: "relative" | "true";
     speed: number;

--- a/codecs/PacketStub.ts
+++ b/codecs/PacketStub.ts
@@ -3,6 +3,7 @@ export interface PacketStub<IdType = string> {
     talkerId?: string;
 
     // User info
+    chxOk?: true;
     sentenceName?: string;
 }
 
@@ -10,11 +11,12 @@ export function initStubFields<IdType>(stub: PacketStub, id: IdType, sentenceNam
     return {
         sentenceId: id,
         talkerId: stub.talkerId,
+        chxOk: stub.chxOk,
         sentenceName
     };
 }
 
-export function parseStub(field0: string): PacketStub {
+export function parseStub(field0: string, chxOk: boolean): PacketStub {
 
     let talkerId: string;
     let sentenceId: string;
@@ -27,5 +29,5 @@ export function parseStub(field0: string): PacketStub {
         sentenceId = field0.substr(3);
     }
 
-    return { talkerId, sentenceId };
+    return { talkerId, sentenceId, chxOk: (chxOk ? chxOk : undefined) };
 }

--- a/codecs/PacketStub.ts
+++ b/codecs/PacketStub.ts
@@ -1,7 +1,15 @@
-export interface PacketStub {
-    sentenceId: string;
+export interface PacketStub<IdType = string> {
+    sentenceId: IdType;
     talkerId?: string;
 
     // User info
     sentenceName?: string;
+}
+
+export function initStubFields<IdType>(stub: PacketStub, id: IdType, sentenceName?: string): PacketStub<IdType> {
+    return {
+        sentenceId: id,
+        talkerId: stub.talkerId,
+        sentenceName
+    };
 }

--- a/codecs/PacketStub.ts
+++ b/codecs/PacketStub.ts
@@ -13,3 +13,19 @@ export function initStubFields<IdType>(stub: PacketStub, id: IdType, sentenceNam
         sentenceName
     };
 }
+
+export function parseStub(field0: string): PacketStub {
+
+    let talkerId: string;
+    let sentenceId: string;
+
+    if (field0.charAt(1) === "P") {
+        talkerId = "P"; // Proprietary
+        sentenceId = field0.substr(2);
+    } else {
+        talkerId = field0.substr(1, 2);
+        sentenceId = field0.substr(3);
+    }
+
+    return { talkerId, sentenceId };
+}

--- a/codecs/PacketStub.ts
+++ b/codecs/PacketStub.ts
@@ -1,0 +1,7 @@
+export interface PacketStub {
+    sentenceId: string;
+    talkerId?: string;
+
+    // User info
+    sentenceName?: string;
+}

--- a/codecs/RDID.ts
+++ b/codecs/RDID.ts
@@ -15,25 +15,23 @@
  */
 
 import { parseFloatSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "RDID" = "RDID";
 export const sentenceName = "RDI proprietary heading, pitch, and roll";
 
 
-export interface RDIDPacket extends PacketStub {
-    sentenceId: "RDID";
+export interface RDIDPacket extends PacketStub<typeof sentenceId> {
     roll: number;
     pitch: number;
     heading: number;
 }
 
 
-export function decodeSentence(fields: string[]): RDIDPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): RDIDPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         roll: parseFloatSafe(fields[1]),
         pitch: parseFloatSafe(fields[2]),
         heading: parseFloatSafe(fields[3])

--- a/codecs/RDID.ts
+++ b/codecs/RDID.ts
@@ -15,16 +15,15 @@
  */
 
 import { parseFloatSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "RDID" = "RDID";
 export const sentenceName = "RDI proprietary heading, pitch, and roll";
 
 
-export interface RDIDPacket {
+export interface RDIDPacket extends PacketStub {
     sentenceId: "RDID";
-    sentenceName?: string;
-    talkerId?: string;
     roll: number;
     pitch: number;
     heading: number;

--- a/codecs/RMC.ts
+++ b/codecs/RMC.ts
@@ -27,15 +27,14 @@
  */
 
 import { parseDatetime, parseFloatSafe, parseLatitude, parseLongitude } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "RMC" = "RMC";
 export const sentenceName = "Recommended minimum navigation information";
 
 
-export interface RMCPacket extends PacketStub {
-    sentenceId: "RMC";
+export interface RMCPacket extends PacketStub<typeof sentenceId> {
     datetime: Date;
     status: "valid" | "warning";
     latitude: number;
@@ -48,10 +47,9 @@ export interface RMCPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): RMCPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): RMCPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         datetime: parseDatetime(fields[9], fields[1]),
         status: fields[2] === "A" ? "valid" : "warning",
         latitude: parseLatitude(fields[3], fields[4]),

--- a/codecs/RMC.ts
+++ b/codecs/RMC.ts
@@ -27,16 +27,15 @@
  */
 
 import { parseDatetime, parseFloatSafe, parseLatitude, parseLongitude } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "RMC" = "RMC";
 export const sentenceName = "Recommended minimum navigation information";
 
 
-export interface RMCPacket {
+export interface RMCPacket extends PacketStub {
     sentenceId: "RMC";
-    sentenceName?: string;
-    talkerId?: string;
     datetime: Date;
     status: "valid" | "warning";
     latitude: number;

--- a/codecs/UnknownPacket.ts
+++ b/codecs/UnknownPacket.ts
@@ -1,0 +1,16 @@
+import { initStubFields, PacketStub } from "./PacketStub";
+
+export const sentenceId: "?" = "?";
+
+export interface UnknownPacket extends PacketStub<typeof sentenceId> {
+    dataFields: string[];
+    originalPacketId: string;
+}
+
+export function decodeSentence(stub: PacketStub, fields: string[]): UnknownPacket {
+    return {
+        ...initStubFields(stub, sentenceId),
+        originalPacketId: stub.sentenceId,
+        dataFields: fields.slice(1)
+    };
+}

--- a/codecs/VHW.ts
+++ b/codecs/VHW.ts
@@ -20,15 +20,14 @@
  */
 
 import { parseFloatSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "VHW" = "VHW";
 export const sentenceName = "Water speed and heading";
 
 
-export interface VHWPacket extends PacketStub {
-    sentenceId: "VHW";
+export interface VHWPacket extends PacketStub<typeof sentenceId> {
     degreesTrue: number;
     degreesMagnetic: number;
     speedKnots: number;
@@ -36,10 +35,9 @@ export interface VHWPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): VHWPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): VHWPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         degreesTrue: parseFloatSafe(fields[1]),
         degreesMagnetic: parseFloatSafe(fields[3]),
         speedKnots: parseFloatSafe(fields[5]),

--- a/codecs/VHW.ts
+++ b/codecs/VHW.ts
@@ -20,16 +20,15 @@
  */
 
 import { parseFloatSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "VHW" = "VHW";
 export const sentenceName = "Water speed and heading";
 
 
-export interface VHWPacket {
+export interface VHWPacket extends PacketStub {
     sentenceId: "VHW";
-    sentenceName?: string;
-    talkerId?: string;
     degreesTrue: number;
     degreesMagnetic: number;
     speedKnots: number;

--- a/codecs/VTG.ts
+++ b/codecs/VTG.ts
@@ -22,16 +22,15 @@
  */
 
 import { createNmeaChecksumFooter, encodeDegrees, encodeFixed, parseFloatSafe } from "../helpers";
+import { PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "VTG" = "VTG";
 export const sentenceName = "Track made good and ground speed";
 
 
-export interface VTGPacket {
+export interface VTGPacket extends PacketStub {
     sentenceId: "VTG";
-    sentenceName?: string;
-    talkerId?: string;
     trackTrue: number;
     trackMagnetic: number;
     speedKnots: number;

--- a/codecs/VTG.ts
+++ b/codecs/VTG.ts
@@ -22,15 +22,14 @@
  */
 
 import { createNmeaChecksumFooter, encodeDegrees, encodeFixed, parseFloatSafe } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "VTG" = "VTG";
 export const sentenceName = "Track made good and ground speed";
 
 
-export interface VTGPacket extends PacketStub {
-    sentenceId: "VTG";
+export interface VTGPacket extends PacketStub<typeof sentenceId> {
     trackTrue: number;
     trackMagnetic: number;
     speedKnots: number;
@@ -39,10 +38,9 @@ export interface VTGPacket extends PacketStub {
 }
 
 
-export function decodeSentence(fields: string[]): VTGPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): VTGPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         trackTrue: parseFloatSafe(fields[1]),
         trackMagnetic: parseFloatSafe(fields[3]),
         speedKnots: parseFloatSafe(fields[5]),

--- a/codecs/ZDA.ts
+++ b/codecs/ZDA.ts
@@ -18,23 +18,21 @@
  */
 
 import { parseIntSafe, parseTime } from "../helpers";
-import { PacketStub } from "./PacketStub";
+import { initStubFields, PacketStub } from "./PacketStub";
 
 
 export const sentenceId: "ZDA" = "ZDA";
 export const sentenceName = "UTC, day, month, year, and local time zone";
 
-export interface ZDAPacket extends PacketStub {
-    sentenceId: "ZDA";
+export interface ZDAPacket extends PacketStub<typeof sentenceId> {
     datetime: Date;
     localZoneHours: number;
     localZoneMinutes: number;
 }
 
-export function decodeSentence(fields: string[]): ZDAPacket {
+export function decodeSentence(stub: PacketStub, fields: string[]): ZDAPacket {
     return {
-        sentenceId: sentenceId,
-        sentenceName: sentenceName,
+        ...initStubFields(stub, sentenceId, sentenceName),
         datetime: parseTime(fields[1], fields.slice(2, 5).join("")),
         localZoneHours: parseIntSafe(fields[5]),
         localZoneMinutes: parseIntSafe(fields[6])

--- a/codecs/ZDA.ts
+++ b/codecs/ZDA.ts
@@ -18,14 +18,14 @@
  */
 
 import { parseIntSafe, parseTime } from "../helpers";
+import { PacketStub } from "./PacketStub";
+
 
 export const sentenceId: "ZDA" = "ZDA";
 export const sentenceName = "UTC, day, month, year, and local time zone";
 
-export interface ZDAPacket {
+export interface ZDAPacket extends PacketStub {
     sentenceId: "ZDA";
-    sentenceName: string;
-    talkerId?: string;
     datetime: Date;
     localZoneHours: number;
     localZoneMinutes: number;

--- a/helpers.ts
+++ b/helpers.ts
@@ -281,66 +281,52 @@ export function parseNumberOrString(str?: string): number | string {
 
 
 /**
+ * Parses coordinate given as "dddmm.mm", "ddmm.mm", "dmm.mm" or "mm.mm"
+ */
+export function parseDmCoordinate(coordinate: string): number {
+
+    const dotIdx = coordinate.indexOf(".");
+
+    if (dotIdx < 0) {
+        return 0;
+    }
+
+    let degrees: string;
+    let minutes: string;
+
+    if (dotIdx >= 3) {
+        degrees = coordinate.substring(0, dotIdx - 2);
+        minutes = coordinate.substring(dotIdx - 2);
+    } else {
+        // no degrees, just minutes (nonstandard but a buggy unit might do this)
+        degrees = "0";
+        minutes = coordinate;
+    }
+
+    return (parseFloat(degrees) + (parseFloat(minutes) / 60.0));
+}
+
+/**
  * Parses latitude given as "ddmm.mm", "dmm.mm" or "mm.mm" (assuming zero
  * degrees) along with a given hemisphere of "N" or "S" into decimal degrees,
- * where north is positive and south is negetive.
+ * where north is positive and south is negative.
  */
 export function parseLatitude(lat: string, hemi: string): number {
     const hemisphere = (hemi === "N") ? 1.0 : -1.0;
 
-    const a = lat.split(".");
-
-    let degrees: string;
-    let minutes: string;
-    if (a[0].length === 4) {
-        // two digits of degrees
-        degrees = lat.substring(0, 2);
-        minutes = lat.substring(2);
-    } else if (a[0].length === 3) {
-        // 1 digit of degrees (in case no leading zero)
-        degrees = lat.substring(0, 1);
-        minutes = lat.substring(1);
-    } else {
-        // no degrees, just minutes (nonstandard but a buggy unit might do this)
-        degrees = "0";
-        minutes = lat;
-    }
-
-    return (parseFloat(degrees) + (parseFloat(minutes) / 60.0)) * hemisphere;
+    return parseDmCoordinate(lat) * hemisphere;
 }
 
 
 /**
  * Parses latitude given as "dddmm.mm", "ddmm.mm", "dmm.mm" or "mm.mm" (assuming
  * zero degrees) along with a given hemisphere of "E" or "W" into decimal
- * degrees, where east is positive and west is negetive.
+ * degrees, where east is positive and west is negative.
  */
 export function parseLongitude(lon: string, hemi: string): number {
-    const h = (hemi === "E") ? 1.0 : -1.0;
+    const hemisphere = (hemi === "E") ? 1.0 : -1.0;
 
-    const a = lon.split(".");
-
-    let degrees: string;
-    let minutes: string;
-    if (a[0].length === 5) {
-        // three digits of degrees
-        degrees = lon.substring(0, 3);
-        minutes = lon.substring(3);
-    } else if (a[0].length === 4) {
-        // 2 digits of degrees (in case no leading zero)
-        degrees = lon.substring(0, 2);
-        minutes = lon.substring(2);
-    } else if (a[0].length === 3) {
-        // 1 digit of degrees (in case no leading zero)
-        degrees = lon.substring(0, 1);
-        minutes = lon.substring(1);
-    } else {
-        // no degrees, just minutes (nonstandard but a buggy unit might do this)
-        degrees = "0";
-        minutes = lon;
-    }
-
-    return (parseFloat(degrees) + (parseFloat(minutes) / 60.0)) * h;
+    return parseDmCoordinate(lon) * hemisphere;
 }
 
 /**

--- a/helpers.ts
+++ b/helpers.ts
@@ -70,6 +70,14 @@ export function createNmeaChecksumFooter(sentenceWithoutChecksum: string): strin
 }
 
 
+/**
+ * Append the correct trailing "*xx" footer for an NMEA string and return the result.
+ */
+export function appendChecksumFooter(sentenceWithoutChecksum: string): string {
+    return sentenceWithoutChecksum + createNmeaChecksumFooter(sentenceWithoutChecksum);
+}
+
+
 
 // =========================================
 // field encoders

--- a/index.ts
+++ b/index.ts
@@ -103,10 +103,10 @@ export class DefaultPacketFactory<CustomPacketType = null> implements PacketFact
     }
 }
 
+const DEFAULT_PACKET_FACTORY = new DefaultPacketFactory();
 
-export function parseNmeaSentence(sentence: string): Packet {
-    const factory = new DefaultPacketFactory();
 
+export function parseGenericPacket<PacketType>(sentence: string, factory: PacketFactory<PacketType>): PacketType {
     if (!validNmeaChecksum(sentence)) {
         throw Error(`Invalid sentence: "${sentence}".`);
     }
@@ -120,6 +120,11 @@ export function parseNmeaSentence(sentence: string): Packet {
     }
 
     return packet;
+}
+
+
+export function parseNmeaSentence(sentence: string): Packet {
+    return parseGenericPacket(sentence, DEFAULT_PACKET_FACTORY);
 }
 
 

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import { decodeSentence as decodeVHW, VHWPacket } from "./codecs/VHW";
 import { decodeSentence as decodeVTG, encodePacket as encodeVTG, VTGPacket } from "./codecs/VTG";
 import { decodeSentence as decodeZDA, ZDAPacket } from "./codecs/ZDA";
 
+import { PacketStub } from "./codecs/PacketStub";
 import { validNmeaChecksum } from "./helpers";
 
 
@@ -26,7 +27,7 @@ export type Packet = APBPacket | BWCPacket | DBTPacket | DTMPacket | GGAPacket |
 export { APBPacket, BWCPacket, DBTPacket, DTMPacket, GGAPacket, GLLPacket, GNSPacket, GSAPacket, GSTPacket, GSVPacket, HDGPacket, HDMPacket, HDTPacket, MTKPacket, MWVPacket, RDIDPacket, RMCPacket, VHWPacket, VTGPacket, ZDAPacket };
 
 
-type Decoder = (parts: string[]) => Packet;
+type Decoder = (stub: PacketStub, parts: string[]) => Packet;
 
 
 const decoders: { [sentenceId: string]: Decoder } = {
@@ -96,9 +97,7 @@ export function parseNmeaSentence(sentence: string): Packet {
         throw Error(`No known parser for sentence ID "${sentenceId}".`);
     }
 
-    const packet = parser(fields);
-    packet.talkerId = talkerId;
-    return packet;
+    return parser({ sentenceId, talkerId }, fields);
 }
 
 

--- a/index.ts
+++ b/index.ts
@@ -86,7 +86,6 @@ export function parseNmeaSentence(sentence: string): Packet {
         talkerId = fields[0].substr(1, 2);
         sentenceId = fields[0].substr(3);
     }
-    fields[0] = sentenceId;
 
     let parser = decoders[sentenceId];
     if (!parser && sentenceId.substr(0, 3) === "MTK") {

--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,7 @@ import { decodeSentence as decodeVHW, VHWPacket } from "./codecs/VHW";
 import { decodeSentence as decodeVTG, encodePacket as encodeVTG, VTGPacket } from "./codecs/VTG";
 import { decodeSentence as decodeZDA, ZDAPacket } from "./codecs/ZDA";
 
-import { PacketStub } from "./codecs/PacketStub";
+import { parseStub, PacketStub } from "./codecs/PacketStub";
 import { validNmeaChecksum } from "./helpers";
 
 
@@ -76,27 +76,18 @@ export function parseNmeaSentence(sentence: string): Packet {
     }
 
     const fields = sentence.split("*")[0].split(",");
+    const stub = parseStub(fields[0]);
 
-    let talkerId: string;
-    let sentenceId: string;
-    if (fields[0].charAt(1) === "P") {
-        talkerId = "P"; // Proprietary
-        sentenceId = fields[0].substr(2);
-    } else {
-        talkerId = fields[0].substr(1, 2);
-        sentenceId = fields[0].substr(3);
-    }
-
-    let parser = decoders[sentenceId];
-    if (!parser && sentenceId.substr(0, 3) === "MTK") {
+    let parser = decoders[stub.sentenceId];
+    if (!parser && stub.sentenceId.substr(0, 3) === "MTK") {
         parser = decodeMTK;
     }
 
     if (!parser) {
-        throw Error(`No known parser for sentence ID "${sentenceId}".`);
+        throw Error(`No known parser for sentence ID "${stub.sentenceId}".`);
     }
 
-    return parser({ sentenceId, talkerId }, fields);
+    return parser(stub, fields);
 }
 
 

--- a/tests/CustomPacketsTest.ts
+++ b/tests/CustomPacketsTest.ts
@@ -1,0 +1,82 @@
+import "should";
+
+import { initStubFields, PacketStub } from "../codecs/PacketStub";
+import { appendChecksumFooter } from "../helpers";
+import { parseGenericPacket, DefaultPacketFactory } from "../index";
+
+
+
+const logSentenceId: "_LOG" = "_LOG";
+
+interface LogPacket extends PacketStub<typeof logSentenceId> {
+    logNum: number;
+    logMsg: string;
+}
+
+const buttonPressSentenceId: "_BTN" = "_BTN";
+
+interface ButtonPressPacket extends PacketStub<typeof buttonPressSentenceId> {
+    buttonId: number;
+    longPress: boolean;
+}
+
+type CustomPackets = LogPacket | ButtonPressPacket;
+
+class CustomPacketFactory extends DefaultPacketFactory<CustomPackets> {
+
+    assembleCustomPacket(stub: PacketStub, fields: string[]): CustomPackets | null {
+        if (stub.talkerId === "P") {
+            if (stub.sentenceId === logSentenceId) {
+                return {
+                    ...initStubFields(stub, logSentenceId),
+                    logNum: parseInt(fields[1], 10),
+                    logMsg: fields[2]
+                };
+            }
+            else if (stub.sentenceId === buttonPressSentenceId) {
+                return {
+                    ...initStubFields(stub, buttonPressSentenceId),
+                    buttonId: parseInt(fields[1], 10),
+                    longPress: fields[2].charAt(0) === "L"
+                };
+            }
+        }
+
+        return null;
+    }
+}
+
+const CUSTOM_PACKET_FACTORY = new CustomPacketFactory();
+
+
+
+describe("CustomPackets", (): void => {
+    it("Unknown throws", (): void => {
+        ((): void => {
+            parseGenericPacket(appendChecksumFooter("$--000,data1,data2"), CUSTOM_PACKET_FACTORY);
+        }).should.throw("No known parser for sentence ID \"000\".");
+    });
+
+
+    it("Log", (): void => {
+        const packet = parseGenericPacket(appendChecksumFooter("$P_LOG,5,everything is ok"), CUSTOM_PACKET_FACTORY);
+
+        if (packet.sentenceId !== logSentenceId) {
+            throw Error("Bad packet type");
+        }
+
+        packet.logNum.should.equal(5);
+        packet.logMsg.should.equal("everything is ok");
+    });
+
+    it("Btn", (): void => {
+        const packet = parseGenericPacket(appendChecksumFooter("$P_BTN,0,L"), CUSTOM_PACKET_FACTORY);
+
+        if (packet.sentenceId !== buttonPressSentenceId) {
+            throw Error("Bad packet type");
+        }
+
+        packet.buttonId.should.equal(0);
+        packet.longPress.should.equal(true);
+    });
+});

--- a/tests/UnsafePacketsTest.ts
+++ b/tests/UnsafePacketsTest.ts
@@ -1,0 +1,27 @@
+import "should";
+
+import { getUnsafePacketId, parseUnsafeNmeaSentence } from "../index";
+
+describe("UnsafeParsing", (): void => {
+    it("Built in NMEA sentence", (): void => {
+        const packet = parseUnsafeNmeaSentence("$GPZDA,160012.71,11,03,2004,-1,00*7D");
+
+        if (packet.sentenceId !== "ZDA") {
+            throw Error("sentenceId should be \"ZDA\"");
+        }
+
+        packet.localZoneHours.should.equal(-1);
+    });
+
+    it("Unknown sentence", (): void => {
+        const packet = parseUnsafeNmeaSentence("$GPTXT,01,01,02,ANTSTATUS=OPEN*2B");
+
+        if (packet.sentenceId !== "?") {
+            throw Error("sentenceId should be \"?\"");
+        }
+
+        packet.dataFields.length.should.equal(4);
+        (packet.talkerId === "GP").should.equal(true);
+        getUnsafePacketId(packet).should.equal("TXT");
+    });
+});

--- a/tests/UnsafePacketsTest.ts
+++ b/tests/UnsafePacketsTest.ts
@@ -24,4 +24,15 @@ describe("UnsafeParsing", (): void => {
         (packet.talkerId === "GP").should.equal(true);
         getUnsafePacketId(packet).should.equal("TXT");
     });
+
+    const BAD_CHECKSUM_SENTENCE = "$IIHDM,201.5,M*21";
+    const GOOD_CHECKSUM_SENTENCE = "$IIDBT,036.41,f,011.10,M,005.99,F*25";
+
+    it("checksum", (): void => {
+        let packet = parseUnsafeNmeaSentence(BAD_CHECKSUM_SENTENCE);
+        (packet.chxOk !== true).should.equal(true);
+
+        packet = parseUnsafeNmeaSentence(GOOD_CHECKSUM_SENTENCE);
+        (packet.chxOk === true).should.equal(true);
+    });
 });

--- a/tests/parsingTest.ts
+++ b/tests/parsingTest.ts
@@ -1,0 +1,14 @@
+import "should";
+
+import { parseDmCoordinate } from "../helpers";
+
+describe("Parse", (): void => {
+    it("Coordinate", (): void => {
+        parseDmCoordinate("0").should.equal(0);
+        parseDmCoordinate("0.0").should.equal(0);
+        parseDmCoordinate("30.00").should.equal(0.5);
+        parseDmCoordinate("130.00").should.equal(1.5);
+        parseDmCoordinate("1030.00").should.equal(10.5);
+        parseDmCoordinate("10030.00").should.equal(100.5);
+    });
+});


### PR DESCRIPTION
**This PR adds the following functional changes:**
- Interface to extend packet types and encoders
- Gracefully handle unknown packets
- Mark packets that have bad checksum and attempt to parse them
- Remove code duplication in coordinate parsing


**Motivation**
- Be able to analyze packet error rate and cause in NMEA log files
- Parse proprietary sentences


**Notes**
100% backward compatible, public facing interfaces were only extended.
I'm coming from the embedded field, so maybe not the best Typescript implementation.
Feel free to correct anything.