### PR TITLE
Fix RMC parsing

### DIFF
--- a/codecs/RMC.ts
+++ b/codecs/RMC.ts
@@ -26,7 +26,7 @@
  * 13. Checksum
  */
 
-import { parseDatetime, parseFloatSafe, parseLatitude, parseLongitude } from "../helpers";
+import { parseFloatSafe, parseLatitude, parseLongitude, parseTime } from "../helpers";
 import { initStubFields, PacketStub } from "./PacketStub";
 
 
@@ -50,7 +50,7 @@ export interface RMCPacket extends PacketStub<typeof sentenceId> {
 export function decodeSentence(stub: PacketStub, fields: string[]): RMCPacket {
     return {
         ...initStubFields(stub, sentenceId, sentenceName),
-        datetime: parseDatetime(fields[9], fields[1]),
+        datetime: parseTime(fields[1], fields[9], true),
         status: fields[2] === "A" ? "valid" : "warning",
         latitude: parseLatitude(fields[3], fields[4]),
         longitude: parseLongitude(fields[5], fields[6]),

--- a/index.ts
+++ b/index.ts
@@ -176,6 +176,6 @@ export function parseUnsafeNmeaSentence(sentence: string): UnsafePacket {
 }
 
 
-export function getUnsafePacketId(packet: UnsafePacket) : string {
+export function getUnsafePacketId(packet: UnsafePacket): string {
     return (packet.sentenceId === "?") ? packet.originalPacketId : packet.sentenceId;
 }

--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,11 @@ import { validNmeaChecksum } from "./helpers";
 export type Packet = APBPacket | BWCPacket | DBTPacket | DTMPacket | GGAPacket | GLLPacket | GNSPacket | GSAPacket | GSTPacket | GSVPacket | HDGPacket | HDMPacket | HDTPacket | MTKPacket | MWVPacket | RDIDPacket | RMCPacket | VHWPacket | VTGPacket | ZDAPacket;
 export { APBPacket, BWCPacket, DBTPacket, DTMPacket, GGAPacket, GLLPacket, GNSPacket, GSAPacket, GSTPacket, GSVPacket, HDGPacket, HDMPacket, HDTPacket, MTKPacket, MWVPacket, RDIDPacket, RMCPacket, VHWPacket, VTGPacket, ZDAPacket };
 
+export function assertPacketIs<IdType extends string, PacketType extends PacketStub = Packet>(packetId: IdType, packet: PacketType): asserts packet is (PacketType & { sentenceId: IdType }) {
+    if (packet.sentenceId !== packetId) {
+        throw new Error(`Was expecting packetId of '${packetId}'. Found '${packet.sentenceId}' instead.`);
+    }
+}
 
 type Decoder = (stub: PacketStub, parts: string[]) => Packet;
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build": "npm run lint && tsc",
     "lint": "tslint *.ts codecs/*.ts examples/*.ts tests/*.ts",
+    "lint-fix": "npm run lint -- --fix",
     "prepublish": "npm run test",
     "test": "npm run build && mocha -R tap dist/tests"
   },

--- a/tests/CustomPacketsTest.ts
+++ b/tests/CustomPacketsTest.ts
@@ -2,7 +2,7 @@ import "should";
 
 import { initStubFields, PacketStub } from "../codecs/PacketStub";
 import { appendChecksumFooter } from "../helpers";
-import { parseGenericPacket, DefaultPacketFactory } from "../index";
+import { assertPacketIs, parseGenericPacket, DefaultPacketFactory } from "../index";
 
 
 
@@ -61,9 +61,7 @@ describe("CustomPackets", (): void => {
     it("Log", (): void => {
         const packet = parseGenericPacket(appendChecksumFooter("$P_LOG,5,everything is ok"), CUSTOM_PACKET_FACTORY);
 
-        if (packet.sentenceId !== logSentenceId) {
-            throw Error("Bad packet type");
-        }
+        assertPacketIs(logSentenceId, packet);
 
         packet.logNum.should.equal(5);
         packet.logMsg.should.equal("everything is ok");
@@ -72,9 +70,7 @@ describe("CustomPackets", (): void => {
     it("Btn", (): void => {
         const packet = parseGenericPacket(appendChecksumFooter("$P_BTN,0,L"), CUSTOM_PACKET_FACTORY);
 
-        if (packet.sentenceId !== buttonPressSentenceId) {
-            throw Error("Bad packet type");
-        }
+        assertPacketIs(buttonPressSentenceId, packet);
 
         packet.buttonId.should.equal(0);
         packet.longPress.should.equal(true);

--- a/tests/RMCtest.ts
+++ b/tests/RMCtest.ts
@@ -1,6 +1,6 @@
 import "should";
 
-import { parseNmeaSentence } from "../index";
+import { assertPacketIs, parseNmeaSentence } from "../index";
 
 
 describe("RMC", (): void => {
@@ -21,4 +21,13 @@ describe("RMC", (): void => {
     packet.should.have.property("variationPole", "W");
   });
 
+  it("miliseconds", (): void => {
+    const packet = parseNmeaSentence("$GNRMC,123411.200,A,4721.2973,N,01906.6971,E,16.19,142.59,040223,,,A,V*37");
+    assertPacketIs("RMC", packet);
+    packet.datetime.getMilliseconds().should.equal(200);
+
+    const packet2 = parseNmeaSentence("$GPRMC,123409.886,V,,,,,16.10,145.36,040223,,,N,V*08");
+    assertPacketIs("RMC", packet2);
+    packet2.datetime.getMilliseconds().should.equal(886);
+  });
 });

--- a/tests/UnsafePacketsTest.ts
+++ b/tests/UnsafePacketsTest.ts
@@ -1,14 +1,12 @@
 import "should";
 
-import { getUnsafePacketId, parseUnsafeNmeaSentence } from "../index";
+import { assertPacketIs, getUnsafePacketId, parseUnsafeNmeaSentence } from "../index";
 
 describe("UnsafeParsing", (): void => {
     it("Built in NMEA sentence", (): void => {
         const packet = parseUnsafeNmeaSentence("$GPZDA,160012.71,11,03,2004,-1,00*7D");
 
-        if (packet.sentenceId !== "ZDA") {
-            throw Error("sentenceId should be \"ZDA\"");
-        }
+        assertPacketIs("ZDA", packet);
 
         packet.localZoneHours.should.equal(-1);
     });
@@ -16,9 +14,7 @@ describe("UnsafeParsing", (): void => {
     it("Unknown sentence", (): void => {
         const packet = parseUnsafeNmeaSentence("$GPTXT,01,01,02,ANTSTATUS=OPEN*2B");
 
-        if (packet.sentenceId !== "?") {
-            throw Error("sentenceId should be \"?\"");
-        }
+        assertPacketIs("?", packet);
 
         packet.dataFields.length.should.equal(4);
         (packet.talkerId === "GP").should.equal(true);


### PR DESCRIPTION
Parsing of milliseconds in RMP packet has failed due to a bug in the old time parsing function.

Since it was only used here, I've removed it, and started using the new parsing function in a compatible way.